### PR TITLE
Fix plan cache handling and sessionStorage cleanup

### DIFF
--- a/widgets/cancel/finalPopup.js
+++ b/widgets/cancel/finalPopup.js
@@ -39,7 +39,7 @@ export async function renderFinalMessage(config, copy, state) {
 
   // ✅ Clear plan info cache after cancellation
   const cacheKey = `subjolt_planinfo_${user.user_subscription_id}`;
-  localStorage.removeItem(cacheKey);
+  sessionStorage.removeItem(cacheKey);
 
   await delay(3000);
 

--- a/widgets/cancel/successPopup.js
+++ b/widgets/cancel/successPopup.js
@@ -69,7 +69,7 @@ export async function renderSuccessPopup(
   // ✅ Clear plan info cache on success
   const user = await getUserContext(config);
   const cacheKey = `subjolt_planinfo_${user.user_subscription_id}`;
-  localStorage.removeItem(cacheKey);
+  sessionStorage.removeItem(cacheKey);
 }
 
 // 🔧 Interpolate {{var}} tags with values from contextVars

--- a/widgets/utils/stripeHandlers.js
+++ b/widgets/utils/stripeHandlers.js
@@ -21,13 +21,7 @@ async function callStripeFunction(action, data) {
 export function clearAndSeedPlanCache(subscriptionId, planInfo) {
   try {
     const cacheKey = `subjolt_planinfo_${subscriptionId}`;
-    sessionStorage.setItem(
-      cacheKey,
-      JSON.stringify({
-        value: planInfo,
-        timestamp: Date.now(),
-      })
-    );
+    sessionStorage.setItem(cacheKey, JSON.stringify(planInfo));
   } catch (err) {
     console.error('⚠️ Failed to seed plan cache', err);
   }


### PR DESCRIPTION
## Summary
- store plan info directly in `clearAndSeedPlanCache`
- remove plan cache from `sessionStorage` in popups

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688102713c1c832dbdac75b09130dfd5