### PR TITLE
Fix preview redirect container check

### DIFF
--- a/widgets/utils/renderHelpers.js
+++ b/widgets/utils/renderHelpers.js
@@ -5,6 +5,10 @@ export function renderPreviewRedirect(
   action = null
 ) {
   const container = document.getElementById('widget-container');
+  if (!container) {
+    console.warn('Widget container element not found');
+    return;
+  }
   container.innerHTML = '';
 
   const wrapper = document.createElement('div');


### PR DESCRIPTION
## Summary
- guard against missing `widget-container` in `renderPreviewRedirect`
- log a warning when the container cannot be found

## Testing
- `npm run build:widget` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881029fa250832daea2b8896eeff6d2