### PR TITLE
Fix banner schedule cancellation

### DIFF
--- a/widgets/utils/stripeHandlers.js
+++ b/widgets/utils/stripeHandlers.js
@@ -145,7 +145,18 @@ export async function cancelSchedule(scheduleId, stripeKey, accountId) {
     account_id: accountId,
   });
 
-  clearAndSeedPlanCache(subscriptionId, result?.data);
+  const subscriptionId =
+    result?.data?.subscription_id || result?.subscription_id || null;
+
+  if (subscriptionId) {
+    clearAndSeedPlanCache(subscriptionId, result?.data);
+  } else {
+    console.warn(
+      '⚠️ cancelSchedule: Missing subscription_id in response',
+      result
+    );
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary
- handle missing subscription_id after cancelSchedule response

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f4325504832daab534d575e0a90a