### PR TITLE
Add DOM helper and save mechanism tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:widget": "vite build --emptyOutDir --outDir dist --ssr widgets/main.js",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "supabase": "^2.30.4",

--- a/widgets/utils/__tests__/domHelpers.test.js
+++ b/widgets/utils/__tests__/domHelpers.test.js
@@ -1,4 +1,4 @@
-import { createHeadline, createButton } from '../domHelpers.js';
+import { createHeadline, createButton, createSubheadline, createSelect } from '../domHelpers.js';
 import { describe, it, expect } from 'vitest';
 
 describe('domHelpers', () => {
@@ -8,10 +8,36 @@ describe('domHelpers', () => {
     expect(el.textContent).toBe('Hello');
   });
 
+  it('createSubheadline returns p with text', () => {
+    const el = createSubheadline('Sub');
+    expect(el.tagName).toBe('P');
+    expect(el.textContent).toBe('Sub');
+  });
+
   it('createButton assigns label and className', () => {
     const btn = createButton('Go', 'primary', () => {});
     expect(btn.tagName).toBe('BUTTON');
     expect(btn.textContent).toBe('Go');
     expect(btn.className).toBe('primary');
+  });
+
+  it('createSelect builds options from values', () => {
+    const select = createSelect([1, 2]);
+    expect(select.tagName).toBe('SELECT');
+    expect(select.children.length).toBe(2);
+    expect(select.children[0].value).toBe('1');
+    expect(select.children[0].textContent).toBe('1 month');
+    expect(select.children[1].textContent).toBe('2 months');
+  });
+
+  it('createSelect handles option objects', () => {
+    const select = createSelect([
+      { value: 'a', label: 'Alpha' },
+      { value: 'b', label: 'Beta' },
+    ]);
+    expect(select.children[0].value).toBe('a');
+    expect(select.children[0].textContent).toBe('Alpha');
+    expect(select.children[1].value).toBe('b');
+    expect(select.children[1].textContent).toBe('Beta');
   });
 });

--- a/widgets/utils/__tests__/handleSaveMechanism.test.js
+++ b/widgets/utils/__tests__/handleSaveMechanism.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../stripeHandlers.js', () => {
+  return {
+    applyStripeDiscount: vi.fn(() => Promise.resolve()),
+    pauseStripeSubscription: vi.fn(() => Promise.resolve({ handled: true })),
+    switchStripePlan: vi.fn(() => Promise.resolve()),
+  };
+});
+
+import { handleSaveMechanism } from '../handleSaveMechanism.js';
+import * as stripeHandlers from '../stripeHandlers.js';
+
+describe('handleSaveMechanism', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handles discount via Stripe', async () => {
+    const config = {
+      credentials: { stripe_secret_key: 'sk' },
+      account_id: 'acct',
+    };
+    const settings = {
+      method: 'Payment Gateway',
+      gateway: 'stripe',
+      promo_code: 'SAVE',
+    };
+    const userContext = {
+      user_subscription_id: 'sub_123',
+      user_plan_name: 'Pro',
+    };
+
+    const result = await handleSaveMechanism({
+      type: 'discount',
+      config,
+      settings,
+      userContext,
+    });
+
+    expect(stripeHandlers.applyStripeDiscount).toHaveBeenCalledWith(
+      'sub_123',
+      'SAVE',
+      'sk',
+      'acct'
+    );
+    expect(result.handled).toBe(true);
+    expect(result.shown).toBe('success');
+    expect(result.contextVars.from_name).toBe('Pro');
+  });
+
+  it('returns URL preview for discount', async () => {
+    const config = { user_subscription_id: 'sub_456' };
+    const settings = {
+      method: 'URL',
+      redirect_template:
+        'https://example.com?sub={{user_subscription_id}}&code={{promo_code}}',
+    };
+    const result = await handleSaveMechanism({
+      type: 'discount',
+      config,
+      settings,
+      userContext: {},
+      preview: true,
+      extra: { promo_code: 'CODE' },
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      preview: true,
+      method: 'URL',
+      gateway: 'URL',
+      action: 'discount',
+      redirectUrl: 'https://example.com?sub=sub_456&code=CODE',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add more DOM helper tests for `createSubheadline` and `createSelect`
- cover `handleSaveMechanism` with Stripe mock tests
- run Vitest in single run mode by default

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688160921708832d9e5285df37f7f118