### PR TITLE
Update README with Deno instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Cancel flow widget and Stripe-powered save mechanisms for subscription recovery.
 
 ## Local Development
 
+- Install [Deno](https://deno.land) using `curl -fsSL https://deno.land/install.sh | sh` or your platform's installer
 - Run `npm install`
 - Add `.env` files to root and/or `widget/` with:
   - `VITE_SUPABASE_URL=...`
@@ -11,7 +12,7 @@ Cancel flow widget and Stripe-powered save mechanisms for subscription recovery.
 - Dev build: `npm run dev`
 - Prod build: `npm run build` → outputs to `site/widget.js`
 - Run unit tests: `npm test`
-- Run edge function tests: `deno test supabase/functions/<function>/`
+- Run edge function tests: `deno test supabase/functions/<function>/` (may require network or certificate configuration)
 
 ## Supabase CLI
 


### PR DESCRIPTION
## Summary
- add installation instructions for Deno
- note network/certificate requirements for edge tests

## Testing
- `npm test` *(fails: waiting for file changes until cancelled)*
- `deno test supabase/functions/validate-customer` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6881609efe54832d9b10bc35722e221c