### PR TITLE
Fix Deno TLS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Cancel flow widget and Stripe-powered save mechanisms for subscription recovery.
 ## Local Development
 
 - Install [Deno](https://deno.land) using `curl -fsSL https://deno.land/install.sh | sh` or your platform's installer
+- If `deno test` fails to download modules due to TLS errors, ensure your CA certificates are up to date and run tests with `DENO_TLS_CA_STORE=system`
 - Run `npm install`
 - Add `.env` files to root and/or `widget/` with:
   - `VITE_SUPABASE_URL=...`
@@ -13,7 +14,7 @@ Cancel flow widget and Stripe-powered save mechanisms for subscription recovery.
 - Dev build: `npm run dev`
 - Prod build: `npm run build` → outputs to `site/widget.js`
 - Run unit tests: `npm test`
-- Run edge function tests: `deno test supabase/functions/<function>/` (may require network or certificate configuration)
+- Run edge function tests: `DENO_TLS_CA_STORE=system deno test supabase/functions/<function>/` (may require network access)
 
 ## Supabase CLI
 


### PR DESCRIPTION
## Summary
- document how to fix TLS errors when running `deno test`

## Testing
- `npm test`
- `for t in supabase/functions/*/index_test.ts; do DENO_TLS_CA_STORE=system deno test --allow-env --allow-net --no-check $t || break; done`

------
https://chatgpt.com/codex/tasks/task_e_6881aa473de0832d9dac7174d2e33fdc