### PR TITLE
Add utils tests for logger, postResponse and stripe handlers

### DIFF
--- a/widgets/utils/__tests__/logger.test.js
+++ b/widgets/utils/__tests__/logger.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../supabaseClient.js', () => {
+  const insertMock = vi.fn();
+  const fromMock = vi.fn(() => ({ insert: insertMock }));
+  return { supabase: { from: fromMock }, __mocks: { insertMock, fromMock } };
+});
+
+import { supabase, __mocks } from '../../supabaseClient.js';
+import { logEvent } from '../logger.js';
+
+const { insertMock, fromMock } = __mocks;
+
+describe('logEvent', () => {
+  beforeEach(() => {
+    insertMock.mockReset();
+    fromMock.mockClear();
+  });
+
+  it('logs event to Supabase', async () => {
+    insertMock.mockResolvedValue({ data: 'ok' });
+
+    await logEvent({ accountId: 'a', step: 's', reasonKey: 'r', config: {} });
+
+    expect(fromMock).toHaveBeenCalledWith('event_logs');
+    expect(insertMock).toHaveBeenCalled();
+  });
+
+  it('handles insert errors gracefully', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    insertMock.mockRejectedValue(new Error('fail'));
+
+    await logEvent({ accountId: 'a', step: 's', reasonKey: 'r', config: {} });
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('skips logging in preview mode', async () => {
+    await logEvent({ accountId: 'a', step: 's', reasonKey: 'r', config: { preview: true } });
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+});

--- a/widgets/utils/__tests__/postResponse.test.js
+++ b/widgets/utils/__tests__/postResponse.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+global.fetch = vi.fn();
+
+import { postResponse } from '../postResponse.js';
+
+describe('postResponse', () => {
+  beforeEach(() => {
+    fetch.mockReset();
+  });
+
+  it('returns true on successful POST', async () => {
+    fetch.mockResolvedValue({ ok: true });
+    const data = { a: 1 };
+    const res = await postResponse(data);
+    expect(fetch).toHaveBeenCalledWith('https://api.retainiq.com/response', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    expect(res).toBe(true);
+  });
+
+  it('handles errors and returns false', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetch.mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
+    const res = await postResponse({});
+    expect(res).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/widgets/utils/__tests__/stripeHandlers.test.js
+++ b/widgets/utils/__tests__/stripeHandlers.test.js
@@ -25,4 +25,27 @@ describe('stripeHandlers', () => {
     const cache = sessionStorage.getItem('subjolt_planinfo_sub');
     expect(cache).not.toBeNull();
   });
+
+  it('cancelPauseSubscription seeds cache', async () => {
+    fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: { p: 1 } }) });
+    await handlers.cancelPauseSubscription('subx', 'sk', 'acct');
+    expect(sessionStorage.getItem('subjolt_planinfo_subx')).not.toBeNull();
+  });
+
+  it('unpauseNow seeds cache when subscription_id returned', async () => {
+    fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: { subscription_id: 'suby', plan: 2 } }) });
+    await handlers.unpauseNow('cust', 'price', 'sk', 'acct');
+    expect(sessionStorage.getItem('subjolt_planinfo_suby')).not.toBeNull();
+  });
+
+  it('cancelSchedule seeds cache', async () => {
+    fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: { subscription_id: 'subz', plan: 3 } }) });
+    await handlers.cancelSchedule('sched', 'sk', 'acct');
+    expect(sessionStorage.getItem('subjolt_planinfo_subz')).not.toBeNull();
+  });
+
+  it('throws error when Stripe call fails', async () => {
+    fetch.mockResolvedValue({ ok: false, json: () => Promise.resolve({ error: 'bad' }) });
+    await expect(handlers.applyStripeDiscount('s','c','sk','acct')).rejects.toThrow('bad');
+  });
 });


### PR DESCRIPTION
## Summary
- add unit tests for `logEvent` covering preview mode and error handling
- test `postResponse` success and failure paths
- extend `stripeHandlers` tests for pause-related handlers and error cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68822bb49028832da5034b66cb7de8dc