### PR TITLE
Add cancel flow tests

### DIFF
--- a/widgets/cancel/__tests__/finalPopup.test.js
+++ b/widgets/cancel/__tests__/finalPopup.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.useFakeTimers();
+vi.mock('../../utils/tracking.js', () => ({ fireAnalytics: vi.fn() }));
+vi.mock('../../utils/logger.js', () => ({ logEvent: vi.fn() }));
+vi.mock('../../utils/renderHelpers.js', () => ({ renderPreviewRedirect: vi.fn() }));
+vi.mock('../../utils/stripeHandlers.js', () => ({ cancelStripeSubscription: vi.fn(() => Promise.resolve()) }));
+vi.mock('../../utils/configHelpers.js', () => ({ getUserContext: vi.fn(() => Promise.resolve({ user_subscription_id: 'sub' })) }));
+
+import { fireAnalytics } from '../../utils/tracking.js';
+import { logEvent } from '../../utils/logger.js';
+import { renderPreviewRedirect } from '../../utils/renderHelpers.js';
+import { cancelStripeSubscription } from '../../utils/stripeHandlers.js';
+import { getUserContext } from '../../utils/configHelpers.js';
+
+const analytics = vi.mocked(fireAnalytics);
+const logger = vi.mocked(logEvent);
+const preview = vi.mocked(renderPreviewRedirect);
+const cancel = vi.mocked(cancelStripeSubscription);
+const userCtx = vi.mocked(getUserContext);
+
+import { renderFinalMessage } from '../finalPopup.js';
+
+describe('renderFinalMessage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="widget-container"></div>';
+    vi.clearAllMocks();
+  });
+
+  it('renders final message and triggers analytics', async () => {
+    const config = { account_id: 'a', preview: true, final: { cancel_enabled: false } };
+    const state = { selectedReason: 'r', writeInFeedback: 'hi' };
+    const copy = { final: {}};
+    const promise = renderFinalMessage(config, copy, state);
+    await vi.runAllTimersAsync();
+    await promise;
+    expect(analytics).toHaveBeenCalledWith('cancel_completed', config);
+    expect(logger).toHaveBeenCalledWith({
+      accountId: 'a',
+      step: 'cancel_completed',
+      reasonKey: 'r',
+      write_in: 'hi',
+      config,
+    });
+    expect(preview).toHaveBeenCalled();
+  });
+});

--- a/widgets/cancel/__tests__/popupCallbacks.test.js
+++ b/widgets/cancel/__tests__/popupCallbacks.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../utils/tracking.js', () => ({ fireAnalytics: vi.fn() }));
+vi.mock('../../utils/logger.js', () => ({ logEvent: vi.fn() }));
+vi.mock('../../utils/handleSaveMechanism.js', () => ({ handleSaveMechanism: vi.fn(() => Promise.resolve({ handled: true })) }));
+vi.mock('../../utils/configHelpers.js', () => ({ getUserContext: vi.fn(() => Promise.resolve({ user_plan_id: 'p1', user_plan_interval: 'month', user_subscription_id: 'sub' })) }));
+vi.mock('../successPopup.js', () => ({ renderSuccessPopup: vi.fn() }));
+
+import { fireAnalytics } from '../../utils/tracking.js';
+import { logEvent } from '../../utils/logger.js';
+import { handleSaveMechanism } from '../../utils/handleSaveMechanism.js';
+import { getUserContext } from '../../utils/configHelpers.js';
+import { renderSuccessPopup } from '../successPopup.js';
+const analytics = vi.mocked(fireAnalytics);
+const logger = vi.mocked(logEvent);
+const saveMechanism = vi.mocked(handleSaveMechanism);
+const userCtx = vi.mocked(getUserContext);
+const successPopup = vi.mocked(renderSuccessPopup);
+const nextStep = vi.fn();
+
+import { renderDiscountPopup } from '../discountPopup.js';
+import { renderPausePopup } from '../pausePopup.js';
+import { renderPlanSwitchPopup } from '../planSwitchPopup.js';
+import { renderBillingCycleSwitchPopup } from '../billingCycleSwitchPopup.js';
+import { renderUserFeedbackPopup } from '../userFeedbackPopup.js';
+
+describe('popup callbacks', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="widget-container"></div><div id="cancel-overlay"></div>';
+    document.body.classList.add('widget-active');
+    vi.clearAllMocks();
+  });
+
+  it('discount popup apply and continue actions', async () => {
+    const state = { currentStepIndex: 0, selectedReason: 'r' };
+    await renderDiscountPopup({}, { amount: '10%', duration: '1m' }, { account_id: 'a' }, {}, state, nextStep);
+    const buttons = document.querySelectorAll('button');
+    await buttons[0].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('discount_selected', { account_id: 'a' });
+    expect(successPopup).toHaveBeenCalled();
+
+    await buttons[1].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('discount_skipped', { account_id: 'a' });
+    expect(state.currentStepIndex).toBe(1);
+    expect(nextStep).toHaveBeenCalled();
+  });
+
+  it('pause popup apply and continue actions', async () => {
+    const state = { currentStepIndex: 0, selectedReason: 'r' };
+    await renderPausePopup({}, { durations: [1] }, { account_id: 'a' }, {}, state, nextStep);
+    const buttons = document.querySelectorAll('button');
+    await buttons[0].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('pause_selected', { account_id: 'a' });
+    expect(successPopup).toHaveBeenCalled();
+
+    await buttons[1].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('pause_skipped', { account_id: 'a' });
+    expect(state.currentStepIndex).toBe(1);
+    expect(nextStep).toHaveBeenCalled();
+  });
+
+  it('plan switch popup apply and continue actions', async () => {
+    const state = { currentStepIndex: 0, selectedReason: 'r' };
+    const plans = [
+      { id: 'p1', name: 'A', price: '$20', interval: 'month' },
+      { id: 'p2', name: 'B', price: '$10', interval: 'month' },
+    ];
+    await renderPlanSwitchPopup({}, { plans }, { account_id: 'a' }, {}, state, nextStep);
+    const buttons = document.querySelectorAll('button');
+    await buttons[0].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('plan_switch_selected', { account_id: 'a' });
+    expect(successPopup).toHaveBeenCalled();
+
+    await buttons[1].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('plan_switch_skipped', { account_id: 'a' });
+    expect(state.currentStepIndex).toBe(1);
+    expect(nextStep).toHaveBeenCalled();
+  });
+
+  it('billing cycle switch popup apply and continue actions', async () => {
+    const state = { currentStepIndex: 0, selectedReason: 'r' };
+    const plans = [
+      { id: 'p1', name: 'A Yearly', price: '$30', interval: 'year' },
+      { id: 'p2', name: 'A Monthly', price: '$20', interval: 'month' },
+    ];
+    await renderBillingCycleSwitchPopup({}, { plans }, { account_id: 'a' }, {}, state, nextStep);
+    const buttons = document.querySelectorAll('button');
+    await buttons[0].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('billing_cycle_switch_selected', { account_id: 'a' });
+    expect(successPopup).toHaveBeenCalled();
+
+    await buttons[1].click();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('billing_cycle_switch_skipped', { account_id: 'a' });
+    expect(state.currentStepIndex).toBe(1);
+    expect(nextStep).toHaveBeenCalled();
+  });
+
+  it('user feedback popup exit and continue actions', async () => {
+    const state = { currentStepIndex: 0, selectedReason: 'r', writeInFeedback: null };
+    await renderUserFeedbackPopup({}, { account_id: 'a' }, {}, state, nextStep);
+    const buttons = document.querySelectorAll('button');
+    await buttons[0].click();
+    expect(analytics).toHaveBeenCalledWith('user_feedback_exit', { account_id: 'a' });
+    expect(document.getElementById('widget-container')).toBeNull();
+    expect(document.body.classList.contains('widget-active')).toBe(false);
+
+    document.body.innerHTML = '<div id="widget-container"></div><div id="cancel-overlay"></div>';
+    document.body.classList.add('widget-active');
+    await renderUserFeedbackPopup({}, { account_id: 'a' }, {}, state, nextStep);
+    const contButtons = document.querySelectorAll('button');
+    const textarea = document.querySelector('textarea');
+    textarea.value = 'hello';
+    await contButtons[1].click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(analytics).toHaveBeenCalledWith('user_feedback_continue', { account_id: 'a' });
+    expect(state.writeInFeedback).toBe('hello');
+    expect(state.currentStepIndex).toBe(1);
+    expect(nextStep).toHaveBeenCalled();
+  });
+});

--- a/widgets/cancel/__tests__/renderNextStep.test.js
+++ b/widgets/cancel/__tests__/renderNextStep.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../discountPopup.js', () => ({ renderDiscountPopup: vi.fn() }));
+vi.mock('../pausePopup.js', () => ({ renderPausePopup: vi.fn() }));
+vi.mock('../planSwitchPopup.js', () => ({ renderPlanSwitchPopup: vi.fn() }));
+vi.mock('../billingCycleSwitchPopup.js', () => ({ renderBillingCycleSwitchPopup: vi.fn() }));
+vi.mock('../userFeedbackPopup.js', () => ({ renderUserFeedbackPopup: vi.fn() }));
+vi.mock('../finalPopup.js', () => ({ renderFinalMessage: vi.fn() }));
+vi.mock('../../utils/logger.js', () => ({ logEvent: vi.fn() }));
+vi.mock('../../utils/tracking.js', () => ({ fireAnalytics: vi.fn() }));
+
+import { renderDiscountPopup } from '../discountPopup.js';
+import { renderPausePopup } from '../pausePopup.js';
+import { renderPlanSwitchPopup } from '../planSwitchPopup.js';
+import { renderBillingCycleSwitchPopup } from '../billingCycleSwitchPopup.js';
+import { renderUserFeedbackPopup } from '../userFeedbackPopup.js';
+import { renderFinalMessage } from '../finalPopup.js';
+import { renderNextStep } from '../reasonPopup.js';
+
+const discountMock = vi.mocked(renderDiscountPopup);
+const pauseMock = vi.mocked(renderPausePopup);
+const planMock = vi.mocked(renderPlanSwitchPopup);
+const billingMock = vi.mocked(renderBillingCycleSwitchPopup);
+const feedbackMock = vi.mocked(renderUserFeedbackPopup);
+const finalMock = vi.mocked(renderFinalMessage);
+
+describe('renderNextStep', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="widget-container"></div>';
+    discountMock.mockClear();
+    pauseMock.mockClear();
+    planMock.mockClear();
+    billingMock.mockClear();
+    feedbackMock.mockClear();
+    finalMock.mockClear();
+  });
+
+  it('invokes discount popup renderer', () => {
+    const state = { currentStepIndex: 0, currentStepSet: [{ type: 'discount.offer' }] };
+    renderNextStep({}, {}, state);
+    expect(discountMock).toHaveBeenCalled();
+  });
+
+  it('invokes pause popup renderer', () => {
+    const state = { currentStepIndex: 0, currentStepSet: [{ type: 'pause.default' }] };
+    renderNextStep({}, {}, state);
+    expect(pauseMock).toHaveBeenCalled();
+  });
+
+  it('handles unknown step type and shows final message', () => {
+    const state = { currentStepIndex: 0, currentStepSet: [{ type: 'unknown' }] };
+    renderNextStep({}, {}, state);
+    expect(finalMock).toHaveBeenCalled();
+    expect(state.currentStepIndex).toBe(1);
+  });
+
+  it('renders final message when no steps left', () => {
+    const state = { currentStepIndex: 0, currentStepSet: [] };
+    renderNextStep({}, {}, state);
+    expect(finalMock).toHaveBeenCalled();
+  });
+});

--- a/widgets/cancel/reasonPopup.js
+++ b/widgets/cancel/reasonPopup.js
@@ -206,3 +206,6 @@ const stepRenderers = {
   user_feedback: (prompt, config, copy, state, goNext) =>
     renderUserFeedbackPopup(prompt, config, copy, state, goNext),
 };
+
+// Expose internal functions for testing purposes
+export { renderNextStep, stepRenderers };


### PR DESCRIPTION
## Summary
- export `renderNextStep` for testing
- test renderer selection and edge cases in cancel flow
- verify each popup handler updates the DOM and analytics
- ensure final message rendering works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68822b74ecc0832d9ec353aad46b0d70