### PR TITLE
Add edge function tests

### DIFF
--- a/supabase/functions/stripe-actions-create_coupon_from_config/index_test.ts
+++ b/supabase/functions/stripe-actions-create_coupon_from_config/index_test.ts
@@ -1,3 +1,35 @@
-import { getCorsHeaders } from "./index.ts";
+import { getCorsHeaders, handler } from "./index.ts";
 function assertEquals(a:unknown,b:unknown){if(a!==b)throw new Error(`Expected ${b}, got ${a}`);}
 Deno.test("cors",()=>{const h=getCorsHeaders();assertEquals(h["Content-Type"],"application/json");});
+
+Deno.test("missing fields returns 400", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ config: {}, account_id: null }),
+  });
+  const res = await handler(req);
+  const body = await res.json();
+  assertEquals(res.status, 400);
+  assertEquals(body.error.includes("Missing"), true);
+});
+
+Deno.test("creates promo code", async () => {
+  const fetchFn = async (_url: string, _opts?: any) =>
+    new Response(JSON.stringify([{ access_token: "tok" }]), { status: 200 });
+  const mockStripe = () => ({
+    coupons: { create: async () => ({ id: "c1" }) },
+    promotionCodes: { create: async () => ({ id: "p1" }) },
+  });
+
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({
+      account_id: "a1",
+      config: { discount: { amount: 10, duration: 1, promo_code: "SAVE", type: "percent" } },
+    }),
+  });
+  const res = await handler(req, { stripe: mockStripe, fetchFn });
+  const body = await res.json();
+  assertEquals(res.status, 200);
+  assertEquals(body.promo.id, "p1");
+});

--- a/supabase/functions/stripe-actions-get_user_plan_info/index.ts
+++ b/supabase/functions/stripe-actions-get_user_plan_info/index.ts
@@ -3,7 +3,10 @@ import Stripe from 'https://esm.sh/stripe@12.6.0?bundle';
 
 console.log('✅ stripe-actions-get_user_plan_info function loaded');
 
-serve(async (req: Request) => {
+export async function handler(
+  req: Request,
+  stripeFactory: any = Stripe,
+) {
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 200, headers: getCorsHeaders() });
   }
@@ -20,7 +23,10 @@ serve(async (req: Request) => {
     }
 
     const { stripe_key, subscription_id } = data;
-    const stripe = Stripe(stripe_key, { apiVersion: '2022-11-15' });
+    const stripe =
+      typeof stripeFactory === 'function'
+        ? stripeFactory(stripe_key, { apiVersion: '2022-11-15' })
+        : stripeFactory;
 
     // Get subscription details first (to extract customer)
     const subscription = await stripe.subscriptions.retrieve(subscription_id, {
@@ -148,7 +154,11 @@ serve(async (req: Request) => {
       { status: 500, headers: getCorsHeaders() }
     );
   }
-});
+}
+
+if (import.meta.main) {
+  serve((req) => handler(req));
+}
 
 export function getCorsHeaders() {
   return {

--- a/supabase/functions/stripe-actions-get_user_plan_info/index_test.ts
+++ b/supabase/functions/stripe-actions-get_user_plan_info/index_test.ts
@@ -1,3 +1,40 @@
-import { getCorsHeaders } from "./index.ts";
+import { getCorsHeaders, handler } from "./index.ts";
 function assertEquals(a:unknown,b:unknown){if(a!==b)throw new Error(`Expected ${b}, got ${a}`);}
 Deno.test("cors",()=>{const h=getCorsHeaders();assertEquals(h["Content-Type"],"application/json");});
+
+Deno.test("missing params returns 400", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ data: {} }),
+  });
+  const res = await handler(req);
+  const body = await res.json();
+  assertEquals(res.status, 400);
+  assertEquals(body.error.includes("Missing"), true);
+});
+
+Deno.test("returns plan info", async () => {
+  const mockStripe = () => ({
+    subscriptions: {
+      retrieve: async () => ({
+        customer: "cus_1",
+        status: "active",
+        items: { data: [{ price: { id: "p1", unit_amount: 1000, recurring: { interval: "month" }, product: { name: "Pro" } }, quantity: 1 }] },
+        cancel_at: null,
+      }),
+      list: async () => ({ data: [] }),
+    },
+    subscriptionSchedules: {
+      list: async () => ({ data: [] }),
+    },
+  });
+
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ data: { stripe_key: "sk", subscription_id: "sub_1" } }),
+  });
+  const res = await handler(req, mockStripe);
+  const body = await res.json();
+  assertEquals(res.status, 200);
+  assertEquals(body.plan_id, "p1");
+});

--- a/supabase/functions/stripe-actions-get_valid_plans/index_test.ts
+++ b/supabase/functions/stripe-actions-get_valid_plans/index_test.ts
@@ -1,3 +1,43 @@
-import { getCorsHeaders } from "./index.ts";
+import { getCorsHeaders, handler } from "./index.ts";
 function assertEquals(a:unknown,b:unknown){ if(a!==b) throw new Error(`Expected ${b}, got ${a}`); }
 Deno.test("cors",()=>{const h=getCorsHeaders();assertEquals(h["Access-Control-Allow-Origin"],"*");});
+
+Deno.test("missing account_id returns 400", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({}),
+  });
+  const res = await handler(req);
+  const body = await res.json();
+  assertEquals(res.status, 400);
+  assertEquals(body.error, "Missing account_id");
+});
+
+Deno.test("returns plans", async () => {
+  const fetchFn = async (_url: string, _opts?: any) =>
+    new Response(JSON.stringify([{ access_token: "tok" }]), { status: 200 });
+  const mockStripe = () => ({
+    prices: {
+      list: async () => ({
+        data: [
+          {
+            id: "p1",
+            recurring: { interval: "month" },
+            unit_amount: 1000,
+            deleted: false,
+            product: { name: "Pro" },
+          },
+        ],
+      }),
+    },
+  });
+
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ account_id: "a1" }),
+  });
+  const res = await handler(req, { stripe: mockStripe, fetchFn });
+  const body = await res.json();
+  assertEquals(res.status, 200);
+  assertEquals(body.plans[0].id, "p1");
+});

--- a/supabase/functions/stripe-actions/index_test.ts
+++ b/supabase/functions/stripe-actions/index_test.ts
@@ -1,4 +1,4 @@
-import { getCorsHeaders } from "./index.ts";
+import { getCorsHeaders, handler } from "./index.ts";
 
 function assertEquals(a: unknown, b: unknown) {
   if (a !== b) throw new Error(`Expected ${b}, got ${a}`);
@@ -7,4 +7,41 @@ function assertEquals(a: unknown, b: unknown) {
 Deno.test("getCorsHeaders", () => {
   const h = getCorsHeaders();
   assertEquals(h["Content-Type"], "application/json");
+});
+
+Deno.test("missing stripe key returns 400", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ action: "cancel_pause", data: {} }),
+  });
+  const res = await handler(req);
+  const body = await res.json();
+  assertEquals(res.status, 400);
+  assertEquals(body.error, "Missing Stripe key");
+});
+
+Deno.test("unpause_now success", async () => {
+  const mockStripe = () => ({
+    subscriptions: {
+      create: async () => ({ id: "sub_123" }),
+    },
+  });
+
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({
+      action: "unpause_now",
+      data: {
+        stripe_key: "sk_test",
+        customer_id: "cus_123",
+        price_id: "price_123",
+        account_id: "acct_1",
+      },
+    }),
+  });
+
+  const res = await handler(req, mockStripe);
+  const body = await res.json();
+  assertEquals(res.status, 200);
+  assertEquals(body.subscription_id, "sub_123");
 });

--- a/supabase/functions/stripe-connect-callback/index.ts
+++ b/supabase/functions/stripe-connect-callback/index.ts
@@ -7,7 +7,10 @@ const supabaseServiceKey = Deno.env.get('SERVICE_ROLE_KEY');
 
 console.log('✅ stripe-connect-callback function loaded');
 
-serve(async (req) => {
+export async function handler(
+  req: Request,
+  fetchFn: typeof fetch = fetch,
+) {
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       status: 200,
@@ -42,7 +45,7 @@ serve(async (req) => {
     );
   }
 
-  const tokenRes = await fetch('https://connect.stripe.com/oauth/token', {
+  const tokenRes = await fetchFn('https://connect.stripe.com/oauth/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
@@ -70,7 +73,7 @@ serve(async (req) => {
 
   console.log('🧪 Insert Stripe credentials for account:', state);
 
-  const insertRes = await fetch(`${supabaseUrl}/rest/v1/credentials`, {
+  const insertRes = await fetchFn(`${supabaseUrl}/rest/v1/credentials`, {
     method: 'POST',
     headers: {
       apikey: supabaseServiceKey,
@@ -111,7 +114,11 @@ serve(async (req) => {
       ...getCorsHeaders(),
     },
   });
-});
+}
+
+if (import.meta.main) {
+  serve((req) => handler(req));
+}
 
 export function getCorsHeaders() {
   return {

--- a/supabase/functions/stripe-connect-callback/index_test.ts
+++ b/supabase/functions/stripe-connect-callback/index_test.ts
@@ -1,3 +1,25 @@
-import { getCorsHeaders } from "./index.ts";
+import { getCorsHeaders, handler } from "./index.ts";
 function assertEquals(a:unknown,b:unknown){if(a!==b)throw new Error(`Expected ${b}, got ${a}`);}
 Deno.test("cors",()=>{const h=getCorsHeaders();assertEquals(h["Access-Control-Allow-Origin"],"*");});
+
+Deno.test("missing params", async () => {
+  const req = new Request("https://example.com/callback", { method: "GET" });
+  const res = await handler(req);
+  const body = await res.json();
+  assertEquals(res.status, 400);
+  assertEquals(body.error.includes("Missing"), true);
+});
+
+Deno.test("success redirect", async () => {
+  const fetchFn = async (_url: string) =>
+    new Response(JSON.stringify({
+      stripe_user_id: "acct_1",
+      access_token: "tok",
+      livemode: false,
+      refresh_token: "ref",
+    }), { status: 200 });
+
+  const req = new Request("https://example.com/callback?code=c&state=a", { method: "GET" });
+  const res = await handler(req, fetchFn);
+  assertEquals(res.status, 302);
+});

--- a/supabase/functions/validate-customer/index.ts
+++ b/supabase/functions/validate-customer/index.ts
@@ -1,12 +1,19 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
-const supabaseUrl = Deno.env.get('PROJECT_URL');
-const supabaseServiceKey = Deno.env.get('SERVICE_ROLE_KEY');
+let supabaseUrl = Deno.env.get('PROJECT_URL');
+let supabaseServiceKey = Deno.env.get('SERVICE_ROLE_KEY');
 
-const supabase = createClient(supabaseUrl, supabaseServiceKey);
+console.log('✅ validate-customer function loaded');
 
-serve(async (req) => {
+export async function handler(
+  req: Request,
+  deps: { supabase?: any } = {},
+) {
+  supabaseUrl = supabaseUrl || Deno.env.get('PROJECT_URL');
+  supabaseServiceKey = supabaseServiceKey || Deno.env.get('SERVICE_ROLE_KEY');
+  const supabase =
+    deps.supabase || createClient(supabaseUrl, supabaseServiceKey);
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       status: 200,
@@ -96,7 +103,11 @@ serve(async (req) => {
       headers: getCorsHeaders(),
     });
   }
-});
+}
+
+if (import.meta.main) {
+  serve((req) => handler(req));
+}
 
 export function getCorsHeaders() {
   return {

--- a/supabase/functions/validate-customer/index_test.ts
+++ b/supabase/functions/validate-customer/index_test.ts
@@ -1,4 +1,4 @@
-import { getCorsHeaders } from "./index.ts";
+import { getCorsHeaders, handler } from "./index.ts";
 
 function assertEquals(actual: unknown, expected: unknown) {
   if (actual !== expected) {
@@ -17,3 +17,55 @@ Deno.test("domain normalization strips port", () => {
   const normalized = input.replace(/:\d+$/, "");
   assertEquals(normalized, "example.com");
 });
+
+Deno.test("missing params returns 400", async () => {
+  Deno.env.set("PROJECT_URL", "http://example.com");
+  Deno.env.set("SERVICE_ROLE_KEY", "key");
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({}),
+  });
+  const res = await handler(req, { supabase: createStub() });
+  const body = await res.json();
+  assertEquals(res.status, 400);
+  assertEquals(body.error, "Missing account_id or domain");
+});
+
+Deno.test("valid customer", async () => {
+  Deno.env.set("PROJECT_URL", "http://example.com");
+  Deno.env.set("SERVICE_ROLE_KEY", "key");
+  const supabase = createStub();
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ account_id: "a1", domain: "example.com" }),
+  });
+  const res = await handler(req, { supabase });
+  const body = await res.json();
+  assertEquals(res.status, 200);
+  assertEquals(body.valid, true);
+  assertEquals(body.tier, "pro");
+});
+
+function createStub() {
+  return {
+    from(table: string) {
+      return {
+        select() {
+          return this;
+        },
+        eq() {
+          return this;
+        },
+        maybeSingle: async () => {
+          if (table === "accounts") {
+            return { data: { domain: ["example.com"], tier: "pro" }, error: null };
+          }
+          if (table === "credentials") {
+            return { data: { access_token: "sk", gateway: "stripe" }, error: null };
+          }
+          return { data: null, error: null };
+        },
+      } as any;
+    },
+  } as any;
+}


### PR DESCRIPTION
## Summary
- export handler functions in edge functions
- support dependency injection for easy mocking
- add Deno tests for happy/error paths for each function

## Testing
- `DENO_TLS_CA_STORE=system deno test --no-check --allow-all --node-modules-dir supabase/functions/stripe-actions`
- `DENO_TLS_CA_STORE=system deno test --no-check --allow-all --node-modules-dir supabase/functions/stripe-actions-create_coupon_from_config`
- `DENO_TLS_CA_STORE=system deno test --no-check --allow-all --node-modules-dir supabase/functions/stripe-actions-get_user_plan_info`
- `DENO_TLS_CA_STORE=system deno test --no-check --allow-all --node-modules-dir supabase/functions/stripe-actions-get_valid_plans`
- `DENO_TLS_CA_STORE=system deno test --no-check --allow-all --node-modules-dir supabase/functions/stripe-connect-callback`
- `DENO_TLS_CA_STORE=system deno test --no-check --allow-all --node-modules-dir supabase/functions/validate-customer`


------
https://chatgpt.com/codex/tasks/task_e_68822bbac138832db522b3bdc26f308e